### PR TITLE
mayhem integration

### DIFF
--- a/.github/workflows/mayhem.yml
+++ b/.github/workflows/mayhem.yml
@@ -1,0 +1,60 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: 'build mayhem fuzzing container'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: mayhem/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+    outputs:
+      image: ${{ steps.meta.outputs.tags }}
+
+  mayhem:
+    needs: build
+    name: 'fuzz ${{ matrix.mayhemfile }}'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mayhemfile:
+          - mayhem/simple.mayhemfile
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Start analysis for ${{ matrix.mayhemfile }}
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ needs.build.outputs.image }} --file ${{ matrix.mayhemfile }} --duration 300
+          sarif-output: sarif

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "xori-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.xori]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "simple"
+path = "fuzz_targets/simple.rs"
+test = false
+doc = false
+
+[profile.release]
+debug = true

--- a/fuzz/fuzz_targets/simple.rs
+++ b/fuzz/fuzz_targets/simple.rs
@@ -1,0 +1,18 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use xori::analysis::analyze::analyze;
+use xori::configuration::*;
+use xori::disasm::*;
+
+fuzz_target!(|data: (u8, Vec<u8>)| {
+    let (m32, mut bytes) = data;
+    let mode = match m32 % 3 {
+        0 => Mode::Mode16,
+        1 => Mode::Mode32,
+        _ => Mode::Mode64,
+    };
+
+    let config_map = Config::new();
+    analyze(&Arch::ArchX86, &mode, &mut bytes, &config_map);
+});

--- a/mayhem/.dockerignore
+++ b/mayhem/.dockerignore
@@ -1,0 +1,3 @@
+/target
+.git
+mayhem/Dockerfile

--- a/mayhem/Dockerfile
+++ b/mayhem/Dockerfile
@@ -1,0 +1,22 @@
+# Build Stage
+FROM ghcr.io/evanrichter/cargo-fuzz:latest as builder
+
+## Add source code to the build stage.
+ADD . /src
+WORKDIR /src
+
+RUN echo building instrumented harnesses && \
+    bash -c "pushd fuzz && cargo +nightly -Z sparse-registry fuzz build && popd" && \
+    mv fuzz/target/x86_64-unknown-linux-gnu/release/simple /simple && \
+    echo done
+
+RUN echo building non-instrumented harnesses && \
+    export RUSTFLAGS="--cfg fuzzing -Clink-dead-code -Cdebug-assertions -C codegen-units=1" && \
+    bash -c "pushd fuzz && cargo +nightly -Z sparse-registry build --release && popd" && \
+    mv fuzz/target/release/simple /simple_no_inst && \
+    echo done
+
+# Package Stage
+FROM rustlang/rust:nightly
+
+COPY --from=builder /simple /simple_no_inst /

--- a/mayhem/simple.mayhemfile
+++ b/mayhem/simple.mayhemfile
@@ -1,0 +1,7 @@
+project: xori
+target: simple
+
+cmds:
+  - cmd: /simple
+  - cmd: /simple_no_inst @@
+    libfuzzer: false

--- a/src/analysis/analyze.rs
+++ b/src/analysis/analyze.rs
@@ -129,28 +129,14 @@ impl Header
         }
         return Ok(0);
     }
-    fn identify(&mut self, binary: &mut [u8])->BinaryType{
-    
-        let test_elf = &binary[0..7];
-        if test_elf.eq(b"\x7f\x45\x4c\x46\x02\x02\x01")
-        {
-            self.binary_type = BinaryType::ELF;
-            return BinaryType::ELF;
-        }
-        let test_pe = &binary[0..2];
-        if test_pe.eq(b"\x4D\x5A")
-        {
-            self.binary_type = BinaryType::PE;
-            return BinaryType::PE;
-        }
-        let test_macho = &binary[0..4];
-        if test_macho.eq(b"\xFE\xED\xFA\xCE")
-        {
-            self.binary_type = BinaryType::MACHO;
-            return BinaryType::MACHO;
-        }
-        self.binary_type = BinaryType::BIN;
-        return BinaryType::BIN;
+    fn identify(&mut self, binary: &mut [u8]) -> BinaryType {
+        self.binary_type = match binary {
+            &mut [0x7f, 0x45, 0x4c, 0x46, 0x02, 0x02, 0x01, ..] => BinaryType::ELF,
+            &mut [0x4d, 0x5a, ..] => BinaryType::PE,
+            &mut [0xfe, 0xed, 0xfa, 0xce, ..] => BinaryType::MACHO,
+            _ => BinaryType::BIN,
+        };
+        self.binary_type
     }
 }
 
@@ -203,7 +189,7 @@ fn disassemble_init(
         {
             // Needed for PE Lifetime
             // Handle Image Building
-            let mut new_binary = MmapMut::map_anon(_header.size_of_image as usize)
+            let mut new_binary = MmapMut::map_anon(1.max(_header.size_of_image as usize))
                 .expect("failed to map the file");
             let mut teb: Vec<u8> = Vec::new();
             let mut peb: Vec<u8> = Vec::new();


### PR DESCRIPTION
This fixes in _src/analyze/analysis.rs_ are added with this PR because fuzzing found them so quickly and would not generate good coverage until they were fixed.

This refactor makes it not panic when less than 7 bytes are available for matching:
```rs
    fn identify(&mut self, binary: &mut [u8]) -> BinaryType {
        self.binary_type = match binary {
            &mut [0x7f, 0x45, 0x4c, 0x46, 0x02, 0x02, 0x01, ..] => BinaryType::ELF,
            &mut [0x4d, 0x5a, ..] => BinaryType::PE,
            &mut [0xfe, 0xed, 0xfa, 0xce, ..] => BinaryType::MACHO,
            _ => BinaryType::BIN,
        };
        self.binary_type
    }
```

For disassembly init, it doesn't return a Result, so I make the mmap at least 1 so that that call succeeds.

```rs
            let mut new_binary = MmapMut::map_anon(1.max(_header.size_of_image as usize))
```
